### PR TITLE
west.yml: Update Zephyr path

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -10,8 +10,9 @@ manifest:
       url-base: https://github.com/phytec
 
   projects:
-    - name: zephyr-phytec
+    - name: zephyr
       remote: phytec
+      repo-path: zephyr-phytec
       revision: v4.0.0-phy1
       import:
         # By using name-allowlist we can clone only the modules that are


### PR DESCRIPTION
The zephyr root directory should be called zephyr and not zephyr-phytec. If it's called zephyr-phytec, west won't find it out-of-the-box.